### PR TITLE
dpdk: add rte_ prefix to ether definitions

### DIFF
--- a/src/dpdkcap.c
+++ b/src/dpdkcap.c
@@ -255,7 +255,7 @@ static struct core_capture_stats* cores_stats_capture_list;
 static const struct rte_eth_conf port_conf_default = {
   .rxmode = {
     .mq_mode = ETH_MQ_RX_NONE,
-    .max_rx_pkt_len = ETHER_MAX_LEN,
+    .max_rx_pkt_len = RTE_ETHER_MAX_LEN,
   }
 };
 
@@ -352,7 +352,7 @@ static int port_init(
   rte_eth_promiscuous_enable(port);
 
   /* Display the port MAC address. */
-  struct ether_addr addr;
+  struct rte_ether_addr addr;
   rte_eth_macaddr_get(port, &addr);
   RTE_LOG(INFO, DPDKCAP, "Port %u: MAC=%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8
       ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ", RXdesc/queue=%d\n",


### PR DESCRIPTION
DPDK commits 35b2d13fd6fd ("net: add rte prefix to ether defines")
and 6d13ea8e8e49 ("net: add rte prefix to ether structures") renamed
ETHER_MAX_LEN to RTE_ETHER_MAX_LEN and struct ether_addr to struct
rte_ether_addr.

Fix the compilation of dpdkcap.c, which currently fails with:

    error: ‘ETHER_MAX_LEN’ undeclared here (not in a function); did you mean ‘RTE_ETHER_MAX_LEN’?
    ...
    error: storage size of ‘addr’ isn’t known

Signed-off-by: Vivien Didelot <vivien.didelot@gmail.com>