### PR TITLE
file size without compression fix

### DIFF
--- a/src/core_write.c
+++ b/src/core_write.c
@@ -69,8 +69,8 @@ static FILE * open_pcap(char * output_file) {
 static int write_pcap(FILE * file, void * src, size_t len) {
   size_t retval;
   // Write file
-  retval = fwrite(src, len, 1, file);
-  if (unlikely(retval != 1)) {
+  retval = fwrite(src, 1, len, file);
+  if (unlikely(retval != len)) {
     RTE_LOG(ERR, DPDKCAP, "Could not write into file: %d (%s)\n",
         errno, strerror(errno));
     return -1;


### PR DESCRIPTION
The return value of file_write_func()  is being treated as bytes in every place of core_write.c. Therefore every implementation of this interface should return bytes, not block count. 
It can be achieved in other way: by multiplying count of blocks which is 'retval' with their size  which is 'len'.